### PR TITLE
Updated to use JDK 8

### DIFF
--- a/bamboo-server/Dockerfile
+++ b/bamboo-server/Dockerfile
@@ -1,6 +1,6 @@
 # Bamboo Server
 #
-# VERSION               0.0.1
+# VERSION               0.0.2
 
 FROM phusion/baseimage:0.9.16
 MAINTAINER H. Wüthrich "hw@5px.ch"
@@ -9,7 +9,7 @@ MAINTAINER H. Wüthrich "hw@5px.ch"
 CMD ["/sbin/my_init"]
 
 # Environment
-ENV BAMBOO_VERSION 5.7.2
+ENV BAMBOO_VERSION 5.13.2
 ENV BAMBOO_HOME /home/bamboo
 
 # Expose web and agent ports
@@ -22,10 +22,10 @@ ADD bamboo-server.sh /etc/service/bamboo-server/run
 # Make sure we get latet packages
 RUN apt-get update && apt-get upgrade -y # 28.01.2015
 
-# Install Java OpenJDK 7 and VCS tools
+# Install Java OpenJDK 8 and VCS tools
 RUN apt-get install -yq python-software-properties && add-apt-repository ppa:webupd8team/java -y && apt-get update
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get install -yq oracle-java7-installer git subversion
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+RUN apt-get install -yq oracle-java8-installer git subversion
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
In order for Bamboo versions newer than 5.9.x to run in this container, you need to use JDK 8.  This is because in Bamboo 5.10 Atlassian switched to tomcat 8.  Failing to use the newer JDK causes the launch to die with "unable to start listeners".  Similar changes may be necessary for the bamboo-agent image, but I haven't gotten that far yet.